### PR TITLE
FHAC-804: Fix NPE when initialize DataManager in performance Test Tool

### DIFF
--- a/PerformanceTestTools/src/main/java/gov/hhs/fha/nhinc/loadtest/DataManager.java
+++ b/PerformanceTestTools/src/main/java/gov/hhs/fha/nhinc/loadtest/DataManager.java
@@ -143,6 +143,9 @@ public final class DataManager {
         if (!propFileLocation.endsWith(File.separator)) {
             propFileLocation += File.separator;
         }
+        if (propertyConfigMap == null){
+            propertyConfigMap = new ConcurrentHashMap<>();
+        }
 
         updatePropertyConfigMap(LOAD_TEST_DATA, (LoadTestData) getLoadTestData());
     }


### PR DESCRIPTION
- Initialize HashMap when construct Data Manager class.
Assign @alameluchidambaram @christophermay07 for peer reviews.