### PR TITLE
CONN-2341 fix-uddi-exchange transformer

### DIFF
--- a/UDDIExchangeTransformerUtility/pom.xml
+++ b/UDDIExchangeTransformerUtility/pom.xml
@@ -29,7 +29,7 @@
 		<compiler.source>1.7</compiler.source>
 		<compiler.target>1.7</compiler.target>
         <connectcorelib.version>5.3.0-SNAPSHOT</connectcorelib.version>
-        <connectcommontypes.version>5.3.0-SNAPSHOT</connectcommontypes.version>
+        <connectcommontypes.version>5.2.0-SNAPSHOT</connectcommontypes.version>
 	</properties>
 
 

--- a/UDDIExchangeTransformerUtility/pom.xml
+++ b/UDDIExchangeTransformerUtility/pom.xml
@@ -28,8 +28,8 @@
 	<properties>
 		<compiler.source>1.7</compiler.source>
 		<compiler.target>1.7</compiler.target>
-        <connectcorelib.version>5.2.0-SNAPSHOT</connectcorelib.version>
-        <connectcommontypes.version>5.2.0-SNAPSHOT</connectcommontypes.version>
+        <connectcorelib.version>5.3.0-SNAPSHOT</connectcorelib.version>
+        <connectcommontypes.version>5.3.0-SNAPSHOT</connectcommontypes.version>
 	</properties>
 
 

--- a/UDDIExchangeTransformerUtility/pom.xml
+++ b/UDDIExchangeTransformerUtility/pom.xml
@@ -29,7 +29,7 @@
 		<compiler.source>1.7</compiler.source>
 		<compiler.target>1.7</compiler.target>
         <connectcorelib.version>5.3.0-SNAPSHOT</connectcorelib.version>
-        <connectcommontypes.version>5.2.0-SNAPSHOT</connectcommontypes.version>
+        <connectcommontypes.version>5.2.0</connectcommontypes.version>
 	</properties>
 
 

--- a/UDDIExchangeTransformerUtility/src/main/java/gov/hhs/fha/nhinc/transformerutility/UDDIExchangeTransformerUtility.java
+++ b/UDDIExchangeTransformerUtility/src/main/java/gov/hhs/fha/nhinc/transformerutility/UDDIExchangeTransformerUtility.java
@@ -58,7 +58,7 @@ public class UDDIExchangeTransformerUtility {
     private static final String LOCAL = "local";
     private static final String UDDI = "uddi";
     private static final String EXCHANGE_1 = "Exchange 1";
-    private static final String PLACE_HOLDER = "<Enter>";
+    private static final String PLACE_HOLDER = "https://testurl/uddi/list";
 
     public static void main(String[] args) {
         try {
@@ -126,11 +126,11 @@ public class UDDIExchangeTransformerUtility {
         exchange.setOrganizationList(orgList);
         exchange.setDisabled(true);
         exList.getExchange().add(exchange);
+        exinfo.setDefaultExchange(exchangeName);
         if (uddiFile) {
             exchange.setUrl(PLACE_HOLDER);
             exinfo.setRefreshInterval(1440l);
             exinfo.setMaxNumberOfBackups(BigInteger.ONE);
-            exinfo.setDefaultExchange(exchangeName);
         }
         exinfo.setExchanges(exList);
         return exinfo;


### PR DESCRIPTION
update the uddi-transformer
xml-format in version 5.3
default-exchange is required in internalExchangeInfo so that null-pointer-exception is not throw